### PR TITLE
Fixed #13 結果ページの修正

### DIFF
--- a/css/sp.css
+++ b/css/sp.css
@@ -100,3 +100,46 @@ face
 	width: 100%;
 	margin: 0 auto;
 }
+
+.result {
+  position: relative;
+  width: 100px;
+  float: left;
+}
+
+.result h2 {
+  font-size: 14px;
+  margin: 0;
+  text-align: center;
+  line-height: 1.2em;
+  font-weight: normal;
+}
+.result ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  border: 1px solid #ccc;
+}
+.result ul li {
+  width: 100px;
+  height: 41.1px;
+  line-height: 41.1px;
+  box-sizing: border-box;
+  text-align: center;
+  font-size: 14px;
+}
+
+.table-head {
+  position: relative;
+  width: 250px;
+  float: left;
+}
+
+.table-head ul li {
+  width: 250px;
+  height: 41.1px;
+  line-height: 41.1px;
+  box-sizing: border-box;
+  text-align: center;
+  font-size: 14px;
+}

--- a/css/sp.css
+++ b/css/sp.css
@@ -96,50 +96,8 @@ face
 }
 .wrap {
 	position: relative;
-  max-width: 1000px;
+	max-width: 1000px;
 	width: 100%;
 	margin: 0 auto;
 }
 
-.result {
-  position: relative;
-  width: 100px;
-  float: left;
-}
-
-.result h2 {
-  font-size: 14px;
-  margin: 0;
-  text-align: center;
-  line-height: 1.2em;
-  font-weight: normal;
-}
-.result ul {
-  margin: 0;
-  padding: 0;
-  list-style: none;
-  border: 1px solid #ccc;
-}
-.result ul li {
-  width: 100px;
-  height: 41.1px;
-  line-height: 41.1px;
-  box-sizing: border-box;
-  text-align: center;
-  font-size: 14px;
-}
-
-.table-head {
-  position: relative;
-  width: 250px;
-  float: left;
-}
-
-.table-head ul li {
-  width: 250px;
-  height: 41.1px;
-  line-height: 41.1px;
-  box-sizing: border-box;
-  text-align: center;
-  font-size: 14px;
-}

--- a/css/style.css
+++ b/css/style.css
@@ -409,4 +409,10 @@ footer.question {
 	color: #ffffff;
 }
 
-
+/*=======================================
+tooltip
+=========================================*/
+.tippy-tooltip a {
+	color: #ffffff;
+	text-decoration: underline;
+}

--- a/css/style.css
+++ b/css/style.css
@@ -306,6 +306,28 @@ survey
   text-align: center;
   font-size: 14px;
 }
+
+.info {
+  position: absolute;
+  right: -50px;
+  top: 32px;
+  width: 50px;
+}
+.info ul {
+  margin-top: 0;
+  padding: 0;
+  list-style: none;
+}
+.info ul li {
+  padding-top: 10px;
+  width: 50px;
+  height: 131.4px;
+  line-height: 131.4px;
+  box-sizing: border-box;
+  text-align: center;
+  font-size: 14px;
+}
+
 /*
 .manager ul li:nth-of-type(2) {
   background: #99cdff;

--- a/css/style.css
+++ b/css/style.css
@@ -16,6 +16,11 @@ body{
 	padding:0;
 	height:auto;
 }
+body {
+	display: flex;
+	flex-direction: column;
+	min-height: 100vh;
+}
 #wrapper{
 	width:100%;
 	max-width:1000px;
@@ -328,7 +333,7 @@ survey
   font-size: 14px;
 }
 
-.info ul li a {
+.info-icon {
   color: #333;
 }
 
@@ -383,23 +388,9 @@ header{
 footer
 =========================================*/
 footer {
+	margin-top: auto;
 	padding: 30px 0 20px;
-	position: fixed;
-	bottom: 0;
 	width: 100%;
-	height: 100px;
-	color: #ffffff;
-	background-image: -webkit-linear-gradient(left, #A5D9C6, #BAE68F);
-	background-image: -o-linear-gradient(left, #A5D9C6, #BAE68F);
-	background-image: linear-gradient(to right, #A5D9C6, #BAE68F);
-}
-
-footer.question {
-	position: relative;
-	padding: 30px 0 20px;
-	bottom: 0;
-	width: 100%;
-	height: 100px;
 	color: #ffffff;
 	background-image: -webkit-linear-gradient(left, #A5D9C6, #BAE68F);
 	background-image: -o-linear-gradient(left, #A5D9C6, #BAE68F);
@@ -407,18 +398,10 @@ footer.question {
 }
 
 .footer-menu {
-  text-align: center;
-  font-size: 14px;
+	text-align: center;
+	font-size: 14px;
 }
 
 .footer-menu a{
 	color: #ffffff;
-}
-
-/*=======================================
-tooltip
-=========================================*/
-.tippy-tooltip a {
-	color: #ffffff;
-	text-decoration: underline;
 }

--- a/css/style.css
+++ b/css/style.css
@@ -279,10 +279,11 @@ survey
 .bg div:nth-of-type(5) {
   background: #ecf0f9;
 }
+
 .manager {
   position: absolute;
   right: 50px;
-  top: -32px;
+  top: -50px;
   width: 100px;
 }
 .manager h2 {
@@ -346,6 +347,7 @@ line-height: 1.3em;
 color: #000; /*文字色*/
 border: 1px solid #000; /*線の太さ・色*/
 border-radius: 8px; /*角の丸み*/
+height:80px;
 }
 .triangle {
 color: #ff8c00;

--- a/css/style.css
+++ b/css/style.css
@@ -373,3 +373,41 @@ header{
 	background-image: -o-linear-gradient(left, #A5D9C6, #BAE68F);
 	background-image: linear-gradient(to right, #A5D9C6, #BAE68F);
 }
+
+/*=======================================
+footer
+=========================================*/
+footer {
+	padding: 30px 0 20px;
+	position: fixed;
+	bottom: 0;
+	width: 100%;
+	height: 100px;
+	color: #ffffff;
+	background-image: -webkit-linear-gradient(left, #A5D9C6, #BAE68F);
+	background-image: -o-linear-gradient(left, #A5D9C6, #BAE68F);
+	background-image: linear-gradient(to right, #A5D9C6, #BAE68F);
+}
+
+footer.question {
+	position: relative;
+	padding: 30px 0 20px;
+	bottom: 0;
+	width: 100%;
+	height: 100px;
+	color: #ffffff;
+	background-image: -webkit-linear-gradient(left, #A5D9C6, #BAE68F);
+	background-image: -o-linear-gradient(left, #A5D9C6, #BAE68F);
+	background-image: linear-gradient(to right, #A5D9C6, #BAE68F);
+}
+
+.footer-menu {
+  text-align: center;
+  font-size: 14px;
+}
+
+.footer-menu a{
+	color: #ffffff;
+}
+
+

--- a/css/style.css
+++ b/css/style.css
@@ -254,7 +254,7 @@ survey
   width: 1000px;
   margin: 0 auto;
 }
-#ex_chart {max-width:910px; position: relative; z-index:999;}
+#ex_chart {max-width:860px; position: relative; z-index:999;}
 .bg {
   overflow: hidden;
   position: absolute;
@@ -263,9 +263,9 @@ survey
 }
 .bg div {
   background: #ffebec;
-  height: 395px;
+  height: 370px;
   float: left;
-  width: 136px;
+  width: 126px;
 }
 .bg div:nth-of-type(2) {
   background: #fff3f3;
@@ -281,7 +281,7 @@ survey
 }
 .manager {
   position: absolute;
-  right: 0;
+  right: 50px;
   top: -32px;
   width: 100px;
 }
@@ -300,8 +300,8 @@ survey
 }
 .manager ul li {
   width: 100px;
-  height: 43.8px;
-  line-height: 43.8px;
+  height: 41.1px;
+  line-height: 41.1px;
   box-sizing: border-box;
   text-align: center;
   font-size: 14px;
@@ -309,7 +309,7 @@ survey
 
 .info {
   position: absolute;
-  right: -50px;
+  right: 0;
   top: 32px;
   width: 50px;
 }
@@ -321,8 +321,8 @@ survey
 .info ul li {
   padding-top: 10px;
   width: 50px;
-  height: 131.4px;
-  line-height: 131.4px;
+  height: 123.3px;
+  line-height: 123.3px;
   box-sizing: border-box;
   text-align: center;
   font-size: 14px;

--- a/css/style.css
+++ b/css/style.css
@@ -327,6 +327,10 @@ survey
   font-size: 14px;
 }
 
+.info ul li a {
+  color: #333;
+}
+
 /*
 .manager ul li:nth-of-type(2) {
   background: #99cdff;

--- a/css/style.css
+++ b/css/style.css
@@ -319,10 +319,9 @@ survey
   list-style: none;
 }
 .info ul li {
-  padding-top: 10px;
   width: 50px;
   height: 123.3px;
-  line-height: 123.3px;
+  line-height: 41.1px;
   box-sizing: border-box;
   text-align: center;
   font-size: 14px;

--- a/index.html
+++ b/index.html
@@ -8,6 +8,7 @@
 	<link rel="stylesheet" href="./css/reset.css">
 	<link rel="stylesheet" href="./css/style.css">
 	<link rel="stylesheet" href="./css/sp.css" media="screen and (max-width: 1000px)">
+	<script src="./dist/vendor.js"></script>
 	<script src="./dist/index.js"></script>
 </head>
 

--- a/index.html
+++ b/index.html
@@ -47,6 +47,13 @@
 		</form>
 
 	</div>
+	<footer>
+		<div class="footer-menu">
+		<ul>
+			<li><a href="#">お問い合わせ</a></li>
+		</ul>
+		</div>
+	</footer>
 </body>
 
 </hmtl>

--- a/package-lock.json
+++ b/package-lock.json
@@ -6253,14 +6253,6 @@
         "setimmediate": "^1.0.4"
       }
     },
-    "tippy.js": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/tippy.js/-/tippy.js-4.0.3.tgz",
-      "integrity": "sha512-an3hGGD29DruVArvST9LhiqrFEK8Lf7/nvhUir2Z/D8LmsmrO3Folw3YoG0ha2QUqbmAMKxpcSOvnHWi3rdl2Q==",
-      "requires": {
-        "popper.js": "^1.14.7"
-      }
-    },
     "tmp": {
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1318,6 +1318,11 @@
         "multicast-dns-service-types": "^1.1.0"
       }
     },
+    "bootstrap": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.3.1.tgz",
+      "integrity": "sha512-rXqOmH1VilAt2DyPzluTi2blhk17bO7ef+zLLPlWvG494pDxcM234pJ8wTc/6R40UWizAIIMgxjvxZg5kmsbag=="
+    },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -2492,6 +2497,12 @@
       "requires": {
         "homedir-polyfill": "^1.0.1"
       }
+    },
+    "expose-loader": {
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/expose-loader/-/expose-loader-0.7.5.tgz",
+      "integrity": "sha512-iPowgKUZkTPX5PznYsmifVj9Bob0w2wTHVkt/eYNPSzyebkUgIedmskf/kcfEIWpiWjg3JRjnW+a17XypySMuw==",
+      "dev": true
     },
     "express": {
       "version": "4.16.4",
@@ -5036,6 +5047,11 @@
       "integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==",
       "dev": true
     },
+    "popper.js": {
+      "version": "1.14.7",
+      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.14.7.tgz",
+      "integrity": "sha512-4q1hNvoUre/8srWsH7hnoSJ5xVmIL4qgz+s4qf2TnJIMyZFUFMGH+9vE7mXynAlHSZ/NdTmmow86muD0myUkVQ=="
+    },
     "portfinder": {
       "version": "1.0.20",
       "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.20.tgz",
@@ -6235,6 +6251,14 @@
       "dev": true,
       "requires": {
         "setimmediate": "^1.0.4"
+      }
+    },
+    "tippy.js": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/tippy.js/-/tippy.js-4.0.3.tgz",
+      "integrity": "sha512-an3hGGD29DruVArvST9LhiqrFEK8Lf7/nvhUir2Z/D8LmsmrO3Folw3YoG0ha2QUqbmAMKxpcSOvnHWi3rdl2Q==",
+      "requires": {
+        "popper.js": "^1.14.7"
       }
     },
     "tmp": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "axios": "^0.18.0",
     "bootstrap": "^4.3.1",
     "jquery": "^3.3.1",
-    "popper.js": "^1.14.7",
-    "tippy.js": "^4.0.3"
+    "popper.js": "^1.14.7"
   }
 }

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "@babel/preset-env": "^7.2.3",
     "babel-loader": "^8.0.5",
     "eslint": "^5.12.0",
+    "expose-loader": "^0.7.5",
     "webpack": "^4.28.4",
     "webpack-cli": "^3.2.1",
     "webpack-dev-server": "^3.1.14"
@@ -16,6 +17,9 @@
   "dependencies": {
     "@babel/polyfill": "^7.2.5",
     "axios": "^0.18.0",
-    "jquery": "^3.3.1"
+    "bootstrap": "^4.3.1",
+    "jquery": "^3.3.1",
+    "popper.js": "^1.14.7",
+    "tippy.js": "^4.0.3"
   }
 }

--- a/q.html
+++ b/q.html
@@ -8,6 +8,7 @@
 	<link rel="stylesheet" href="./css/reset.css">
 	<link rel="stylesheet" href="./css/style.css">
 	<link rel="stylesheet" href="./css/sp.css" media="screen and (max-width: 1000px)">
+	<script src="./dist/vendor.js"></script>
 	<script src="./dist/q.js"></script>
 </head>
 

--- a/q.html
+++ b/q.html
@@ -44,7 +44,7 @@
 			</form>
 
 		</div>
-	<footer class="question">
+	<footer>
 		<div class="footer-menu">
 		<ul>
 			<li><a href="#">お問い合わせ</a></li>

--- a/q.html
+++ b/q.html
@@ -44,6 +44,13 @@
 			</form>
 
 		</div>
+	<footer class="question">
+		<div class="footer-menu">
+		<ul>
+			<li><a href="#">お問い合わせ</a></li>
+		</ul>
+		</div>
+	</footer>
 	</body>
 
 </hmtl>

--- a/result.html
+++ b/result.html
@@ -24,5 +24,12 @@
         </div>
     </div>
 </div>
+<footer>
+	<div class="footer-menu">
+	<ul>
+		<li><a href="#">お問い合わせ</a></li>
+	</ul>
+	</div>
+</footer>
 </body>
 </html>

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,3 @@
-import $ from 'jquery';
-
 $(document).ready(() => {
   $('form').on('submit', function(evt) {
     evt.preventDefault();

--- a/src/q.js
+++ b/src/q.js
@@ -1,4 +1,3 @@
-import $ from 'jquery';
 import axios from 'axios';
 
 const getParams = () => {

--- a/src/result.js
+++ b/src/result.js
@@ -48,7 +48,26 @@ $(document).ready(() => {
     gap[i] = (userScore[i] - meanScore[i]).toFixed(2);
   }
 
+  const $tableHeadEl = $('#table-head');
+  for(let title of labels) {
+    $tableHeadEl.append(`<li>${title}</li>`);
+  }
 
+  const $userScoreEl = $('#user-score');
+  for(let score of userScore.slice(0,9)) {
+    $userScoreEl.append(`<li>${score}</li>`);
+  }
+
+  const $managerMeanScoreEl = $('#manager-mean-score');
+  for(const score of managerMeanScore) {
+    $managerMeanScoreEl.append(`<li>${score}</li>`);
+  }
+
+  const $memberMeanScoreEl = $('#member-mean-score');
+  for(const score of memberMeanScore) {
+    $memberMeanScoreEl.append(`<li>${score}</li>`);
+  }
+  
   $('.user-postion').text(isManager ? 'マネージャー' : 'メンバー');
   const $gapEl = $('#gap');
   for(const d of gap) {

--- a/src/result.js
+++ b/src/result.js
@@ -47,27 +47,17 @@ $(document).ready(() => {
   for(let i = 0; i < meanScore.length; i++) {
     gap[i] = (userScore[i] - meanScore[i]).toFixed(2);
   }
-
-  const $tableHeadEl = $('#table-head');
-  for(let title of labels) {
-    $tableHeadEl.append(`<li>${title}</li>`);
-  }
-
-  const $userScoreEl = $('#user-score');
-  for(let score of userScore.slice(0,9)) {
-    $userScoreEl.append(`<li>${score}</li>`);
-  }
-
-  const $managerMeanScoreEl = $('#manager-mean-score');
-  for(const score of managerMeanScore) {
-    $managerMeanScoreEl.append(`<li>${score}</li>`);
-  }
-
-  const $memberMeanScoreEl = $('#member-mean-score');
-  for(const score of memberMeanScore) {
-    $memberMeanScoreEl.append(`<li>${score}</li>`);
-  }
   
+  //スマホ用のテーブルを描画
+  for(let i = 0; i < labels.length; i++) {
+    let info_icon = "";
+    if(i % 3 == 0) {
+      const modal = (i/3) + 1;
+      info_icon = `<td rowspan="3"><a class="info-icon" href="#" data-toggle="modal" data-target="#my-modal-${modal}"><i class="fas fa-exclamation-circle"></i></a></td>`;
+    }
+    $(".table > tbody").append(`<tr><th>${labels[i]}</th><td>${userScore[i]}</td><td>${managerMeanScore[i]}</td><td>${memberMeanScore[i]}</td><td>${gap[i]}</td>${info_icon}</tr>`);
+  }
+
   $('.user-postion').text(isManager ? 'マネージャー' : 'メンバー');
   const $gapEl = $('#gap');
   for(const d of gap) {

--- a/src/result.js
+++ b/src/result.js
@@ -1,5 +1,3 @@
-import $ from 'jquery';
-
 $(document).ready(() => {
   const calcScore = () => {
     const scores = Array(11).fill(0);
@@ -116,5 +114,6 @@ $(document).ready(() => {
     data: data,
     options: options
   });
-
+  
+  $('[data-toggle="tooltip"]').tooltip();
 });

--- a/surveyresults.html
+++ b/surveyresults.html
@@ -9,7 +9,6 @@
 	<link rel="stylesheet" href="css/style.css">
 	<link rel="stylesheet" href="css/sp.css" media="screen and (max-width: 1000px)">
 	<script src="js/dist/Chart.js"></script>
-	<script src="https://unpkg.com/tippy.js@3/dist/tippy.all.min.js"></script>
 	<script src="js/dist/Chart.bundle.js"></script>
 	<script src="js/utils.js"></script>
 </head>
@@ -170,9 +169,7 @@
 		</ul>
 		</div>
 	</footer>
+	<script src="dist/vendor.js"></script>
 	<script src="dist/result.js"></script>
-	<script src="https://code.jquery.com/jquery-3.3.1.slim.min.js" integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo" crossorigin="anonymous"></script>
-	<script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.7/umd/popper.min.js" integrity="sha384-UO2eT0CpHqdSJQ6hJty5KVphtPhzWj9WO1clHTMGa3JDZwrnQq4sF86dIHNDz0W1" crossorigin="anonymous"></script>
-	<script src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js" integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM" crossorigin="anonymous"></script>
 </body>
 </html>

--- a/surveyresults.html
+++ b/surveyresults.html
@@ -19,6 +19,21 @@
 		</div>
 	</header>
 	<div id="wrapper">
+		<div class="table-responsive sp">
+		    <table class="table" id="result">
+			<thead>
+			    <tr>
+				<th>項目</th>
+				<th>あなたのスコア</th>
+				<th>マネージャーの平均スコア</th>
+				<th>メンバーの平均スコア</th>
+				<th><span class="user-postion"></span><br>平均との<br>GAP</th>
+				<th></th>
+			    </tr>
+			</thead>
+			<tbody />
+		    </table>
+		</div>
 		<div class="score pc">
 			<table>
 				<tbody id="q_title">
@@ -35,51 +50,29 @@
 				</tbody>
 			</table>
 		</div>
-		<div class="wrap">
-			<div class="bg pc">
+		<div class="wrap pc">
+			<div class="bg">
 				<div></div>
 				<div></div>
 				<div></div>
 				<div></div>
 				<div></div>
 			</div>
-			<div class="result table-head sp">
-				<h2 class="kakoi">項目</h2>
-				<ul id="table-head">
-				</ul>
-			</div>
-			<div class="result user sp">
-				<h2 class="kakoi">あなたのスコア</h2>
-				<ul id="user-score">
-				</ul>
-			</div>
-			<div class="result manager-mean sp">
-				<h2 class="kakoi">マネージャーの平均スコア</h2>
-				<ul id="manager-mean-score">
-				</ul>
-			</div>
-			<div class="result member-mean sp">
-				<h2 class="kakoi">メンバーの平均スコア</h2>
-				<ul id="member-mean-score">
-				</ul>
-			</div>
-			<div class="result manager">
+			<div class="manager">
 				<h2 class="kakoi"><span class="user-postion"></span><br>平均との<br>GAP</h2>
 				<ul id="gap">
 				</ul>
 			</div>
 			<div class="info">
 				<ul>
-					<li><a href="#" data-toggle="modal" data-target="#my-modal-1"><i class="fas fa-exclamation-circle"></i></a></li>
-					<li><a href="#" data-toggle="modal" data-target="#my-modal-2"><i class="fas fa-exclamation-circle"></i></a></li>
-					<li><a href="#" data-toggle="modal" data-target="#my-modal-3"><i class="fas fa-exclamation-circle"></i></a></li>
+					<li><a class="info-icon" href="#" data-toggle="modal" data-target="#my-modal-1"><i class="fas fa-exclamation-circle"></i></a></li>
+					<li><a class="info-icon" href="#" data-toggle="modal" data-target="#my-modal-2"><i class="fas fa-exclamation-circle"></i></a></li>
+					<li><a class="info-icon" href="#" data-toggle="modal" data-target="#my-modal-3"><i class="fas fa-exclamation-circle"></i></a></li>
 				</ul>
 			</div>
-			<div class="chart-content pc">
+			<div class="chart-content">
 			    <canvas id="ex_chart"></canvas>
 			</div>
-		</div>
-	</div>
 			<div class="modal fade" id="my-modal-1" tabindex="-1" role="dialog" aria-labelledby="myModalLabel">
 				<div class="modal-dialog" role="document">
 					<div class="modal-content">
@@ -162,12 +155,14 @@
 					</div>
 				</div>
 			</div>
-	<footer>
-		<div class="footer-menu">
-		<ul>
-			<li><a href="#">お問い合わせ</a></li>
-		</ul>
 		</div>
+	</div>
+	<footer>
+	    <div class="footer-menu">
+		<ul>
+		    <li><a href="#">お問い合わせ</a></li>
+		</ul>
+	    </div>
 	</footer>
 	<script src="dist/vendor.js"></script>
 	<script src="dist/result.js"></script>

--- a/surveyresults.html
+++ b/surveyresults.html
@@ -42,7 +42,6 @@
 				<div></div>
 				<div></div>
 			</div>
-
 			<div class="manager">
 
 				<h2 class="kakoi"><span class="user-postion"></span><br>平均との<br>GAP</h2>
@@ -51,9 +50,10 @@
 			</div>
 			<div class="info">
 				<ul>
-					<li class="tooltip" data-tippy="<h3>ご提案可能な解決策例</h3><ul><li>営業戦略・組織方針徹底ワークショップの開催</li><li>営業勝ちパターン、営業活動モデル作成</li><h3>参考サプリ記事（一部）</h3><ul><li><a href='#'>「脱俗人化！営業ノウハウの共有方法とは？「勝ちパターン」見える化する」</a></li><li><a href='#'>「営業プロセスを具体化しているか？営業マネジメントについて」</a></li><li><a href='#'>「営業チームで顧客ポートフォリオを共有しているか」</a></li></ul>" data-tippy-placement="right-start" data-tippy-interactive="true"><i class="fas fa-exclamation-circle"></i></li>
-					<li class="tooltip" data-tippy="<strong>メンバーの平均スコアとは<strong><br>過去実施の8社・約80部署のメンバーの平均スコアです。" data-tippy-placement="right-start"><i class="fas fa-exclamation-circle"></i></li>
-					<li class="tooltip" data-tippy="<strong>メンバーの平均スコアとは<strong><br>過去実施の8社・約80部署のメンバーの平均スコアです。" data-tippy-placement="right-start"><i class="fas fa-exclamation-circle"></i></li>
+					<li class="tooltip" data-tippy="<h3>ご提案可能な解決策例</h3><ul><li>営業戦略・組織方針徹底ワークショップの開催</li><li>営業勝ちパターン、営業活動モデル作成</li><h3>参考サプリ記事（一部）</h3><ul><li><a href='https://www.eigyousapuri.jp/teammaking/20180410_675'>「脱俗人化！営業ノウハウの共有方法とは？「勝ちパターン」見える化する」</a></li><li><a href='https://www.eigyousapuri.jp/teammaking/20180828_1278'>「営業プロセスを具体化しているか？営業マネジメントについて」</a></li><li><a href='https://www.eigyousapuri.jp/teammaking/20181009_1424'>「営業チームで顧客ポートフォリオを共有しているか」</a></li></ul>" data-tippy-placement="right-start" data-tippy-interactive="true"><i class="fas fa-exclamation-circle"></i></li>
+					<li class="tooltip" data-tippy="<h3>ご提案可能な解決策例</h3><ul><li>マネジャー向け個別アドバイスサービス</li><li>ナレッジマネジメント活動、ツール作成支援</li><h3>参考サプリ記事（一部）</h3><ul><li><a href='https://www.eigyousapuri.jp/teammaking/20190115_1840'>「営業リーダーは営業マネジャーとどう違うのか」</a></li><li><a href='https://www.eigyousapuri.jp/teammaking/20181211_1765'>「営業チームで行う、事例勉強会のコツは」
+</a></li><li><a href='https://www.eigyousapuri.jp/teammaking/20181023_1475'>「ロールプレイングの正しいやり方を知っているか」</a></li></ul>" data-tippy-placement="right-start" data-tippy-interactive="true"><i class="fas fa-exclamation-circle"></i></li>
+					<li class="tooltip" data-tippy="<h3>ご提案可能な解決策例</h3><ul><li>営業コア業務設計支援</li><li>営業支援ツール調達支援</li><h3>参考サプリ記事（一部）</h3><ul><li><a href='https://www.eigyousapuri.jp/teammaking/20180515_775'>「営業のコツは商談管理表にあり！効果的な営業会議の進め方」</a></li><li><a href='https://www.eigyousapuri.jp/teammaking/20180626_940'>「営業のナレッジマネジメント！ナレッジの共有には「シクミ」と「シカケ」が必要だ！」</a></li></ul>" data-tippy-placement="right-start" data-tippy-interactive="true"><i class="fas fa-exclamation-circle"></i></li>
 				</ul>
 			</div>
 			<canvas id="ex_chart"></canvas>

--- a/surveyresults.html
+++ b/surveyresults.html
@@ -2,6 +2,7 @@
 <html>
 <head>
 	<title>Logarithmic Line Chart</title>
+	<meta name="viewport" content="width=device-width,initial-scale=1">
 	<link rel="stylesheet" href="css/reset.css">
 	<link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous">
 	<link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.7.2/css/all.css" integrity="sha384-fnmOCqbTlWIlj8LyTjo7mOUStjsKC4pOpQbqyi7RrhN7udi9RwhKkMHpvLbHG9Sr" crossorigin="anonymous">
@@ -19,7 +20,7 @@
 		</div>
 	</header>
 	<div id="wrapper">
-		<div class="score">
+		<div class="score pc">
 			<table>
 				<tbody id="q_title">
 				<tr>
@@ -36,15 +37,34 @@
 			</table>
 		</div>
 		<div class="wrap">
-			<div class="bg">
+			<div class="bg pc">
 				<div></div>
 				<div></div>
 				<div></div>
 				<div></div>
 				<div></div>
 			</div>
-			<div class="manager">
-
+			<div class="result table-head sp">
+				<h2 class="kakoi">項目</h2>
+				<ul id="table-head">
+				</ul>
+			</div>
+			<div class="result user sp">
+				<h2 class="kakoi">あなたのスコア</h2>
+				<ul id="user-score">
+				</ul>
+			</div>
+			<div class="result manager-mean sp">
+				<h2 class="kakoi">マネージャーの平均スコア</h2>
+				<ul id="manager-mean-score">
+				</ul>
+			</div>
+			<div class="result member-mean sp">
+				<h2 class="kakoi">メンバーの平均スコア</h2>
+				<ul id="member-mean-score">
+				</ul>
+			</div>
+			<div class="result manager">
 				<h2 class="kakoi"><span class="user-postion"></span><br>平均との<br>GAP</h2>
 				<ul id="gap">
 				</ul>
@@ -53,9 +73,14 @@
 				<ul>
 					<li><a href="#" data-toggle="modal" data-target="#my-modal-1"><i class="fas fa-exclamation-circle"></i></a></li>
 					<li><a href="#" data-toggle="modal" data-target="#my-modal-2"><i class="fas fa-exclamation-circle"></i></a></li>
-					<li><a href="#" data-toggle="modal" data-target="#my-modal-3"><i class="fas fa-exclamation-circle"></i><a></li>
+					<li><a href="#" data-toggle="modal" data-target="#my-modal-3"><i class="fas fa-exclamation-circle"></i></a></li>
 				</ul>
 			</div>
+			<div class="chart-content pc">
+			    <canvas id="ex_chart"></canvas>
+			</div>
+		</div>
+	</div>
 			<div class="modal fade" id="my-modal-1" tabindex="-1" role="dialog" aria-labelledby="myModalLabel">
 				<div class="modal-dialog" role="document">
 					<div class="modal-content">
@@ -138,9 +163,6 @@
 					</div>
 				</div>
 			</div>
-			<canvas id="ex_chart"></canvas>
-		</div>
-	</div>
 	<footer>
 		<div class="footer-menu">
 		<ul>

--- a/surveyresults.html
+++ b/surveyresults.html
@@ -3,6 +3,7 @@
 <head>
 	<title>Logarithmic Line Chart</title>
 	<link rel="stylesheet" href="css/reset.css">
+	<link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous">
 	<link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.7.2/css/all.css" integrity="sha384-fnmOCqbTlWIlj8LyTjo7mOUStjsKC4pOpQbqyi7RrhN7udi9RwhKkMHpvLbHG9Sr" crossorigin="anonymous">
 	<link rel="stylesheet" href="css/style.css">
 	<link rel="stylesheet" href="css/sp.css" media="screen and (max-width: 1000px)">
@@ -24,12 +25,12 @@
 				<tr>
 					<th class="triangle">&#9650;</th>
 					<td>マネージャーの平均スコア</td>
-					<td class="tooltip" data-tippy="<strong>マネジャーの平均スコアとは<strong><br>過去実施の8社・約80部署のマネジャーの平均スコアです。" data-tippy-placement="right-start"><img src="assets/hatena.svg" width="16" height="16"></td>
+					<td data-tippy="<strong>マネジャーの平均スコアとは<strong><br>過去実施の8社・約80部署のマネジャーの平均スコアです。" data-tippy-placement="right-start"><img src="assets/hatena.svg" width="16" height="16"></td>
 				</tr>
 				<tr>
 					<th p class="circle">&#x25CF;</th>
 					<td>メンバーの平均スコア</td>
-					<td class="maru_half tooltip" data-tippy="<strong>メンバーの平均スコアとは<strong><br>過去実施の8社・約80部署のメンバーの平均スコアです。" data-tippy-placement="right-start"><img src="assets/hatena.svg" width="16" height="16"></td>
+					<td class="maru_half" data-tippy="<strong>メンバーの平均スコアとは<strong><br>過去実施の8社・約80部署のメンバーの平均スコアです。" data-tippy-placement="right-start"><img src="assets/hatena.svg" width="16" height="16"></td>
 				</tr>
 				</tbody>
 			</table>
@@ -50,11 +51,92 @@
 			</div>
 			<div class="info">
 				<ul>
-					<li class="tooltip" data-tippy="<h3>ご提案可能な解決策例</h3><ul><li>営業戦略・組織方針徹底ワークショップの開催</li><li>営業勝ちパターン、営業活動モデル作成</li><h3>参考サプリ記事（一部）</h3><ul><li><a href='https://www.eigyousapuri.jp/teammaking/20180410_675'>「脱俗人化！営業ノウハウの共有方法とは？「勝ちパターン」見える化する」</a></li><li><a href='https://www.eigyousapuri.jp/teammaking/20180828_1278'>「営業プロセスを具体化しているか？営業マネジメントについて」</a></li><li><a href='https://www.eigyousapuri.jp/teammaking/20181009_1424'>「営業チームで顧客ポートフォリオを共有しているか」</a></li></ul>" data-tippy-placement="right-start" data-tippy-interactive="true"><i class="fas fa-exclamation-circle"></i></li>
-					<li class="tooltip" data-tippy="<h3>ご提案可能な解決策例</h3><ul><li>マネジャー向け個別アドバイスサービス</li><li>ナレッジマネジメント活動、ツール作成支援</li><h3>参考サプリ記事（一部）</h3><ul><li><a href='https://www.eigyousapuri.jp/teammaking/20190115_1840'>「営業リーダーは営業マネジャーとどう違うのか」</a></li><li><a href='https://www.eigyousapuri.jp/teammaking/20181211_1765'>「営業チームで行う、事例勉強会のコツは」
-</a></li><li><a href='https://www.eigyousapuri.jp/teammaking/20181023_1475'>「ロールプレイングの正しいやり方を知っているか」</a></li></ul>" data-tippy-placement="right-start" data-tippy-interactive="true"><i class="fas fa-exclamation-circle"></i></li>
-					<li class="tooltip" data-tippy="<h3>ご提案可能な解決策例</h3><ul><li>営業コア業務設計支援</li><li>営業支援ツール調達支援</li><h3>参考サプリ記事（一部）</h3><ul><li><a href='https://www.eigyousapuri.jp/teammaking/20180515_775'>「営業のコツは商談管理表にあり！効果的な営業会議の進め方」</a></li><li><a href='https://www.eigyousapuri.jp/teammaking/20180626_940'>「営業のナレッジマネジメント！ナレッジの共有には「シクミ」と「シカケ」が必要だ！」</a></li></ul>" data-tippy-placement="right-start" data-tippy-interactive="true"><i class="fas fa-exclamation-circle"></i></li>
+					<li><a href="#" data-toggle="modal" data-target="#my-modal-1"><i class="fas fa-exclamation-circle"></i></a></li>
+					<li><a href="#" data-toggle="modal" data-target="#my-modal-2"><i class="fas fa-exclamation-circle"></i></a></li>
+					<li><a href="#" data-toggle="modal" data-target="#my-modal-3"><i class="fas fa-exclamation-circle"></i><a></li>
 				</ul>
+			</div>
+			<div class="modal fade" id="my-modal-1" tabindex="-1" role="dialog" aria-labelledby="myModalLabel">
+				<div class="modal-dialog" role="document">
+					<div class="modal-content">
+						<div class="modal-header">
+							<h3 class="modal-title">ご提案可能な解決策例</h3>
+							<button type="button" class="close" data-dismiss="modal" aria-label="閉じる">
+								<span aria-hidden="true">&times;</span>
+							</button>
+						</div>
+						<div class="modal-body">
+							<ul>
+								<li>営業戦略・組織方針徹底ワークショップの開催</li>
+								<li>営業勝ちパターン、営業活動モデル作成</li>
+							</ul>
+							<h4>参考サプリ記事（一部）</h4>
+							<ul>
+								<li><a href='https://www.eigyousapuri.jp/teammaking/20180410_675'>「脱俗人化！営業ノウハウの共有方法とは？「勝ちパターン」見える化する」</a></li>
+								<li><a href='https://www.eigyousapuri.jp/teammaking/20180828_1278'>「営業プロセスを具体化しているか？営業マネジメントについて」</a></li>
+								<li><a href='https://www.eigyousapuri.jp/teammaking/20181009_1424'>「営業チームで顧客ポートフォリオを共有しているか」</a></li>
+							</ul>
+						</div>
+						<div class="modal-footer">
+							<button type="button" class="btn btn-secondary" data-dismiss="modal">閉じる</button>
+						</div>
+					</div>
+				</div>
+			</div>
+
+
+			<div class="modal fade" id="my-modal-2" tabindex="-1" role="dialog" aria-labelledby="myModalLabel">
+				<div class="modal-dialog" role="document">
+					<div class="modal-content">
+						<div class="modal-header">
+							<h3 class="modal-title">ご提案可能な解決策例</h3>
+							<button type="button" class="close" data-dismiss="modal" aria-label="閉じる">
+								<span aria-hidden="true">&times;</span>
+							</button>
+						</div>
+						<div class="modal-body">
+							<ul>
+								<li>マネジャー向け個別アドバイスサービス</li>
+								<li>ナレッジマネジメント活動、ツール作成支援</li>
+							</ul>
+							<h4>参考サプリ記事（一部）</h4>
+							<ul>
+								<li><a href='https://www.eigyousapuri.jp/teammaking/20190115_1840'>「営業リーダーは営業マネジャーとどう違うのか」</a></li>
+								<li><a href='https://www.eigyousapuri.jp/teammaking/20181211_1765'>「営業チームで行う、事例勉強会のコツは」-</a></li>
+								<li><a href='https://www.eigyousapuri.jp/teammaking/20181023_1475'>「ロールプレイングの正しいやり方を知っているか」</a></li>
+							</ul>
+						</div>
+						<div class="modal-footer">
+							<button type="button" class="btn btn-secondary" data-dismiss="modal">閉じる</button>
+						</div>
+					</div>
+				</div>
+			</div>
+			<div class="modal fade" id="my-modal-3" tabindex="-1" role="dialog" aria-labelledby="myModalLabel">
+				<div class="modal-dialog" role="document">
+					<div class="modal-content">
+						<div class="modal-header">
+							<h3 class="modal-title">ご提案可能な解決策例</h3>
+							<button type="button" class="close" data-dismiss="modal" aria-label="閉じる">
+								<span aria-hidden="true">&times;</span>
+							</button>
+						</div>
+						<div class="modal-body">
+							<ul>
+								<li>営業コア業務設計支援</li>
+								<li>営業支援ツール調達支援</li>
+							</ul>
+							<h4>参考サプリ記事（一部）</h4>
+							<ul>
+								<li><a href='https://www.eigyousapuri.jp/teammaking/20180515_775'>「営業のコツは商談管理表にあり！効果的な営業会議の進め方」</a></li>
+								<li><a href='https://www.eigyousapuri.jp/teammaking/20180626_940'>「営業のナレッジマネジメント！ナレッジの共有には「シクミ」と「シカケ」が必要だ！」</a></li>
+							</ul>
+						</div>
+						<div class="modal-footer">
+							<button type="button" class="btn btn-secondary" data-dismiss="modal">閉じる</button>
+						</div>
+					</div>
+				</div>
 			</div>
 			<canvas id="ex_chart"></canvas>
 		</div>
@@ -67,5 +149,8 @@
 		</div>
 	</footer>
 	<script src="dist/result.js"></script>
+	<script src="https://code.jquery.com/jquery-3.3.1.slim.min.js" integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo" crossorigin="anonymous"></script>
+	<script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.7/umd/popper.min.js" integrity="sha384-UO2eT0CpHqdSJQ6hJty5KVphtPhzWj9WO1clHTMGa3JDZwrnQq4sF86dIHNDz0W1" crossorigin="anonymous"></script>
+	<script src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js" integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM" crossorigin="anonymous"></script>
 </body>
 </html>

--- a/surveyresults.html
+++ b/surveyresults.html
@@ -2,7 +2,8 @@
 <html>
 <head>
 	<title>Logarithmic Line Chart</title>
-	<meta name="viewport" content="width=device-width,initial-scale=1">
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<meta http-equiv="X-UA-Compatible" content="ie=edge">
 	<link rel="stylesheet" href="css/reset.css">
 	<link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous">
 	<link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.7.2/css/all.css" integrity="sha384-fnmOCqbTlWIlj8LyTjo7mOUStjsKC4pOpQbqyi7RrhN7udi9RwhKkMHpvLbHG9Sr" crossorigin="anonymous">
@@ -40,12 +41,12 @@
 				<tr>
 					<th class="triangle">&#9650;</th>
 					<td>マネージャーの平均スコア</td>
-					<td data-tippy="<strong>マネジャーの平均スコアとは<strong><br>過去実施の8社・約80部署のマネジャーの平均スコアです。" data-tippy-placement="right-start"><img src="assets/hatena.svg" width="16" height="16"></td>
+					<td data-toggle="tooltip" data-html="true" title="<strong>マネジャーの平均スコアとは<strong><br>過去実施の8社・約80部署のマネジャーの平均スコアです。" data-placement="right"><img src="assets/hatena.svg" width="16" height="16"></td>
 				</tr>
 				<tr>
 					<th p class="circle">&#x25CF;</th>
 					<td>メンバーの平均スコア</td>
-					<td class="maru_half" data-tippy="<strong>メンバーの平均スコアとは<strong><br>過去実施の8社・約80部署のメンバーの平均スコアです。" data-tippy-placement="right-start"><img src="assets/hatena.svg" width="16" height="16"></td>
+					<td class="maru_half" data-toggle="tooltip" data-html="true" title="<strong>メンバーの平均スコアとは<strong><br>過去実施の8社・約80部署のメンバーの平均スコアです。" data-placement="right"><img src="assets/hatena.svg" width="16" height="16"></td>
 				</tr>
 				</tbody>
 			</table>

--- a/surveyresults.html
+++ b/surveyresults.html
@@ -48,6 +48,13 @@
 				<ul id="gap">
 				</ul>
 			</div>
+			<div class="info">
+				<ul>
+					<li class="maru_half tooltip" data-tippy="<h3>ご提案可能な解決策例</h3><ul><li>営業戦略・組織方針徹底ワークショップの開催</li><li>営業勝ちパターン、営業活動モデル作成</li><h3>参考サプリ記事（一部）</h3><ul><li><a href='#'>「脱俗人化！営業ノウハウの共有方法とは？「勝ちパターン」見える化する」</a></li><li><a href='#'>「営業プロセスを具体化しているか？営業マネジメントについて」</a></li><li><a href='#'>「営業チームで顧客ポートフォリオを共有しているか」</a></li></ul>" data-tippy-placement="right-start" data-tippy-interactive="true"><img src="assets/hatena.svg" width="16" height="16"></li>
+					<li class="maru_half tooltip" data-tippy="<strong>メンバーの平均スコアとは<strong><br>過去実施の8社・約80部署のメンバーの平均スコアです。" data-tippy-placement="right-start"><img src="assets/hatena.svg" width="16" height="16"></li>
+					<li class="maru_half tooltip" data-tippy="<strong>メンバーの平均スコアとは<strong><br>過去実施の8社・約80部署のメンバーの平均スコアです。" data-tippy-placement="right-start"><img src="assets/hatena.svg" width="16" height="16"></li>
+				</ul>
+			</div>
 			<canvas id="ex_chart"></canvas>
 		</div>
 	</div>

--- a/surveyresults.html
+++ b/surveyresults.html
@@ -73,85 +73,84 @@
 			<div class="chart-content">
 			    <canvas id="ex_chart"></canvas>
 			</div>
-			<div class="modal fade" id="my-modal-1" tabindex="-1" role="dialog" aria-labelledby="myModalLabel">
-				<div class="modal-dialog" role="document">
-					<div class="modal-content">
-						<div class="modal-header">
-							<h3 class="modal-title">ご提案可能な解決策例</h3>
-							<button type="button" class="close" data-dismiss="modal" aria-label="閉じる">
-								<span aria-hidden="true">&times;</span>
-							</button>
-						</div>
-						<div class="modal-body">
-							<ul>
-								<li>営業戦略・組織方針徹底ワークショップの開催</li>
-								<li>営業勝ちパターン、営業活動モデル作成</li>
-							</ul>
-							<h4>参考サプリ記事（一部）</h4>
-							<ul>
-								<li><a href='https://www.eigyousapuri.jp/teammaking/20180410_675'>「脱俗人化！営業ノウハウの共有方法とは？「勝ちパターン」見える化する」</a></li>
-								<li><a href='https://www.eigyousapuri.jp/teammaking/20180828_1278'>「営業プロセスを具体化しているか？営業マネジメントについて」</a></li>
-								<li><a href='https://www.eigyousapuri.jp/teammaking/20181009_1424'>「営業チームで顧客ポートフォリオを共有しているか」</a></li>
-							</ul>
-						</div>
-						<div class="modal-footer">
-							<button type="button" class="btn btn-secondary" data-dismiss="modal">閉じる</button>
-						</div>
+		</div>
+		<div class="modal fade" id="my-modal-1" tabindex="-1" role="dialog" aria-labelledby="myModalLabel">
+			<div class="modal-dialog" role="document">
+				<div class="modal-content">
+					<div class="modal-header">
+						<h3 class="modal-title">ご提案可能な解決策例</h3>
+						<button type="button" class="close" data-dismiss="modal" aria-label="閉じる">
+							<span aria-hidden="true">&times;</span>
+						</button>
+					</div>
+					<div class="modal-body">
+						<ul>
+							<li>営業戦略・組織方針徹底ワークショップの開催</li>
+							<li>営業勝ちパターン、営業活動モデル作成</li>
+						</ul>
+						<h4>参考サプリ記事（一部）</h4>
+						<ul>
+							<li><a href='https://www.eigyousapuri.jp/teammaking/20180410_675'>「脱俗人化！営業ノウハウの共有方法とは？「勝ちパターン」見える化する」</a></li>
+							<li><a href='https://www.eigyousapuri.jp/teammaking/20180828_1278'>「営業プロセスを具体化しているか？営業マネジメントについて」</a></li>
+							<li><a href='https://www.eigyousapuri.jp/teammaking/20181009_1424'>「営業チームで顧客ポートフォリオを共有しているか」</a></li>
+						</ul>
+					</div>
+					<div class="modal-footer">
+						<button type="button" class="btn btn-secondary" data-dismiss="modal">閉じる</button>
 					</div>
 				</div>
 			</div>
+		</div>
 
-
-			<div class="modal fade" id="my-modal-2" tabindex="-1" role="dialog" aria-labelledby="myModalLabel">
-				<div class="modal-dialog" role="document">
-					<div class="modal-content">
-						<div class="modal-header">
-							<h3 class="modal-title">ご提案可能な解決策例</h3>
-							<button type="button" class="close" data-dismiss="modal" aria-label="閉じる">
-								<span aria-hidden="true">&times;</span>
-							</button>
-						</div>
-						<div class="modal-body">
-							<ul>
-								<li>マネジャー向け個別アドバイスサービス</li>
-								<li>ナレッジマネジメント活動、ツール作成支援</li>
-							</ul>
-							<h4>参考サプリ記事（一部）</h4>
-							<ul>
-								<li><a href='https://www.eigyousapuri.jp/teammaking/20190115_1840'>「営業リーダーは営業マネジャーとどう違うのか」</a></li>
-								<li><a href='https://www.eigyousapuri.jp/teammaking/20181211_1765'>「営業チームで行う、事例勉強会のコツは」-</a></li>
-								<li><a href='https://www.eigyousapuri.jp/teammaking/20181023_1475'>「ロールプレイングの正しいやり方を知っているか」</a></li>
-							</ul>
-						</div>
-						<div class="modal-footer">
-							<button type="button" class="btn btn-secondary" data-dismiss="modal">閉じる</button>
-						</div>
+		<div class="modal fade" id="my-modal-2" tabindex="-1" role="dialog" aria-labelledby="myModalLabel">
+			<div class="modal-dialog" role="document">
+				<div class="modal-content">
+					<div class="modal-header">
+						<h3 class="modal-title">ご提案可能な解決策例</h3>
+						<button type="button" class="close" data-dismiss="modal" aria-label="閉じる">
+							<span aria-hidden="true">&times;</span>
+						</button>
+					</div>
+					<div class="modal-body">
+						<ul>
+							<li>マネジャー向け個別アドバイスサービス</li>
+							<li>ナレッジマネジメント活動、ツール作成支援</li>
+						</ul>
+						<h4>参考サプリ記事（一部）</h4>
+						<ul>
+							<li><a href='https://www.eigyousapuri.jp/teammaking/20190115_1840'>「営業リーダーは営業マネジャーとどう違うのか」</a></li>
+							<li><a href='https://www.eigyousapuri.jp/teammaking/20181211_1765'>「営業チームで行う、事例勉強会のコツは」-</a></li>
+							<li><a href='https://www.eigyousapuri.jp/teammaking/20181023_1475'>「ロールプレイングの正しいやり方を知っているか」</a></li>
+						</ul>
+					</div>
+					<div class="modal-footer">
+						<button type="button" class="btn btn-secondary" data-dismiss="modal">閉じる</button>
 					</div>
 				</div>
 			</div>
-			<div class="modal fade" id="my-modal-3" tabindex="-1" role="dialog" aria-labelledby="myModalLabel">
-				<div class="modal-dialog" role="document">
-					<div class="modal-content">
-						<div class="modal-header">
-							<h3 class="modal-title">ご提案可能な解決策例</h3>
-							<button type="button" class="close" data-dismiss="modal" aria-label="閉じる">
-								<span aria-hidden="true">&times;</span>
-							</button>
-						</div>
-						<div class="modal-body">
-							<ul>
-								<li>営業コア業務設計支援</li>
-								<li>営業支援ツール調達支援</li>
-							</ul>
-							<h4>参考サプリ記事（一部）</h4>
-							<ul>
-								<li><a href='https://www.eigyousapuri.jp/teammaking/20180515_775'>「営業のコツは商談管理表にあり！効果的な営業会議の進め方」</a></li>
-								<li><a href='https://www.eigyousapuri.jp/teammaking/20180626_940'>「営業のナレッジマネジメント！ナレッジの共有には「シクミ」と「シカケ」が必要だ！」</a></li>
-							</ul>
-						</div>
-						<div class="modal-footer">
-							<button type="button" class="btn btn-secondary" data-dismiss="modal">閉じる</button>
-						</div>
+		</div>
+		<div class="modal fade" id="my-modal-3" tabindex="-1" role="dialog" aria-labelledby="myModalLabel">
+			<div class="modal-dialog" role="document">
+				<div class="modal-content">
+					<div class="modal-header">
+						<h3 class="modal-title">ご提案可能な解決策例</h3>
+						<button type="button" class="close" data-dismiss="modal" aria-label="閉じる">
+							<span aria-hidden="true">&times;</span>
+						</button>
+					</div>
+					<div class="modal-body">
+						<ul>
+							<li>営業コア業務設計支援</li>
+							<li>営業支援ツール調達支援</li>
+						</ul>
+						<h4>参考サプリ記事（一部）</h4>
+						<ul>
+							<li><a href='https://www.eigyousapuri.jp/teammaking/20180515_775'>「営業のコツは商談管理表にあり！効果的な営業会議の進め方」</a></li>
+							<li><a href='https://www.eigyousapuri.jp/teammaking/20180626_940'>「営業のナレッジマネジメント！ナレッジの共有には「シクミ」と「シカケ」が必要だ！」</a></li>
+						</ul>
+					</div>
+					<div class="modal-footer">
+						<button type="button" class="btn btn-secondary" data-dismiss="modal">閉じる</button>
 					</div>
 				</div>
 			</div>

--- a/surveyresults.html
+++ b/surveyresults.html
@@ -3,6 +3,7 @@
 <head>
 	<title>Logarithmic Line Chart</title>
 	<link rel="stylesheet" href="css/reset.css">
+	<link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.7.2/css/all.css" integrity="sha384-fnmOCqbTlWIlj8LyTjo7mOUStjsKC4pOpQbqyi7RrhN7udi9RwhKkMHpvLbHG9Sr" crossorigin="anonymous">
 	<link rel="stylesheet" href="css/style.css">
 	<link rel="stylesheet" href="css/sp.css" media="screen and (max-width: 1000px)">
 	<script src="js/dist/Chart.js"></script>
@@ -50,9 +51,9 @@
 			</div>
 			<div class="info">
 				<ul>
-					<li class="maru_half tooltip" data-tippy="<h3>ご提案可能な解決策例</h3><ul><li>営業戦略・組織方針徹底ワークショップの開催</li><li>営業勝ちパターン、営業活動モデル作成</li><h3>参考サプリ記事（一部）</h3><ul><li><a href='#'>「脱俗人化！営業ノウハウの共有方法とは？「勝ちパターン」見える化する」</a></li><li><a href='#'>「営業プロセスを具体化しているか？営業マネジメントについて」</a></li><li><a href='#'>「営業チームで顧客ポートフォリオを共有しているか」</a></li></ul>" data-tippy-placement="right-start" data-tippy-interactive="true"><img src="assets/hatena.svg" width="16" height="16"></li>
-					<li class="maru_half tooltip" data-tippy="<strong>メンバーの平均スコアとは<strong><br>過去実施の8社・約80部署のメンバーの平均スコアです。" data-tippy-placement="right-start"><img src="assets/hatena.svg" width="16" height="16"></li>
-					<li class="maru_half tooltip" data-tippy="<strong>メンバーの平均スコアとは<strong><br>過去実施の8社・約80部署のメンバーの平均スコアです。" data-tippy-placement="right-start"><img src="assets/hatena.svg" width="16" height="16"></li>
+					<li class="tooltip" data-tippy="<h3>ご提案可能な解決策例</h3><ul><li>営業戦略・組織方針徹底ワークショップの開催</li><li>営業勝ちパターン、営業活動モデル作成</li><h3>参考サプリ記事（一部）</h3><ul><li><a href='#'>「脱俗人化！営業ノウハウの共有方法とは？「勝ちパターン」見える化する」</a></li><li><a href='#'>「営業プロセスを具体化しているか？営業マネジメントについて」</a></li><li><a href='#'>「営業チームで顧客ポートフォリオを共有しているか」</a></li></ul>" data-tippy-placement="right-start" data-tippy-interactive="true"><i class="fas fa-exclamation-circle"></i></li>
+					<li class="tooltip" data-tippy="<strong>メンバーの平均スコアとは<strong><br>過去実施の8社・約80部署のメンバーの平均スコアです。" data-tippy-placement="right-start"><i class="fas fa-exclamation-circle"></i></li>
+					<li class="tooltip" data-tippy="<strong>メンバーの平均スコアとは<strong><br>過去実施の8社・約80部署のメンバーの平均スコアです。" data-tippy-placement="right-start"><i class="fas fa-exclamation-circle"></i></li>
 				</ul>
 			</div>
 			<canvas id="ex_chart"></canvas>

--- a/surveyresults.html
+++ b/surveyresults.html
@@ -58,6 +58,13 @@
 			<canvas id="ex_chart"></canvas>
 		</div>
 	</div>
+	<footer>
+		<div class="footer-menu">
+		<ul>
+			<li><a href="#">お問い合わせ</a></li>
+		</ul>
+		</div>
+	</footer>
 	<script src="dist/result.js"></script>
 </body>
 </html>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -28,7 +28,7 @@ const js = {
 
 const vendorScript = {
   mode: 'development',
-  entry: ["jquery", "popper.js", "bootstrap", "tippy.js"],
+  entry: ["jquery", "popper.js", "bootstrap"],
   output: {
     filename: "vendor.js",
     path: path.join(__dirname, "dist")

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,11 +1,12 @@
 const path = require('path');
-
+const webpack = require("webpack");
 const js = {
   mode: 'development',
   entry: {
     index: path.resolve(__dirname, 'src', 'index.js'),
     q: path.resolve(__dirname, 'src', 'q.js'),
     result: path.resolve(__dirname, 'src', 'result.js')
+    
   },
   output: {
     path: path.resolve(__dirname, 'dist'),
@@ -22,7 +23,38 @@ const js = {
         ]
       }
     ]
-  }
+  },
 };
 
-module.exports = js;
+const vendorScript = {
+  mode: 'development',
+  entry: ["jquery", "popper.js", "bootstrap", "tippy.js"],
+  output: {
+    filename: "vendor.js",
+    path: path.join(__dirname, "dist")
+  },
+  module: {
+    rules: [{
+      test: require.resolve("jquery"),
+      use: [{
+        loader: "expose-loader", // global に jQuery / $ を公開
+        options: "jQuery"
+      }, {
+        loader: "expose-loader",
+        options: "$"
+      }]
+    }]
+  },
+  plugins: [
+    // bootstrap のコードから jQuery が直接見えるように
+    // http://getbootstrap.com/docs/4.0/getting-started/webpack/#importing-javascript
+    new webpack.ProvidePlugin({
+      $: "jquery",
+      jQuery: "jquery",
+      "window.jQuery": "jquery",
+      Popper: ["popper.js", "default"]
+    })
+  ]
+};
+
+module.exports = [js, vendorScript]


### PR DESCRIPTION
refs #13 

# サインの部分
- class=manager要素を参考にしました。
   - position:absoluteに
   - グラフを親要素として、-100pxの位置に配置
   - ul要素 liの高さを絶対値で指定(managerのliの3つ分なので3倍)
   - ~~アイコンの高さが数字と揃ってなかったのでpadding-top: 10px;を指定(よくわかってない)~~
- ?アイコンが画像でassetに入っている。同じセットの!アイコンがあれば使いたい
    - webfont-awesomeをビックリマークアイコンを使うことにした
    - 高さは line-heightで調整 1番上のリストに揃えるようにした
- ~~モーダルの出し方がわからないので、他で使っていたtooltipを仮に使った。~~
    - bootstrapを導入して、モーダルウィンドウを出した。
    - idの命名規則がこれでいいのか分からない
    - webpack側で$をグローバル空間にexportする設定を入れた。
        - これをいれないとdist/util.jsと正常に動かなくなった。
        - 途中までjqueryをcdnで読み込んでいたが上記の設定で整理した 
    - class="tooltip"はbootstrapの命名規則とかぶっているようなので一旦消した
- スマホ側は一番右端のtd要素にいれた(rowspan=3)
[![Image from Gyazo](https://i.gyazo.com/5467b2bc8d9e4e20924b30ea42b8a13a.gif)](https://gyazo.com/5467b2bc8d9e4e20924b30ea42b8a13a)

# お問い合わせを追加
- ssrのフッターを参考に実装
- footerタグをwrapperの下に追加
- コンテンツの高さによらず、最下部に表示する
    - flex-boxを使用
    - https://qiita.com/nozomi716/items/2b09d5bce3d08d1c41f9
- ヘッダと同じ配色
- お問い合わせのリンクはまだ空
- 参考 https://techacademy.jp/magazine/19410

# スマホのときはグラフの代わりに表を出す

- pcのGAP部分と共通化しようと思ったが、崩れずに表示するのが難しかった
- そこでpc用の領域とスマホ用の領域を分けた。class="pc"とclass="sp"で出し分け
- スマホ側はbootstrapのtableで組んだ
  - result.js側で値を計算してtr要素を組み立てることにした
  - グラフの描画処理の途中に書いてしまったので若干読みづらい。。。

[![Image from Gyazo](https://i.gyazo.com/ea0a70654ab38d07add791c76771b71b.gif)](https://gyazo.com/ea0a70654ab38d07add791c76771b71b)