### PR TITLE
fixed #25 ソリューション例の表示を改善

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -259,7 +259,7 @@ survey
   width: 1000px;
   margin: 0 auto;
 }
-#ex_chart {max-width:860px; position: relative; z-index:999;}
+#ex_chart {max-width:810px; height:430px; position: relative; z-index:999;}
 .bg {
   overflow: hidden;
   position: absolute;
@@ -270,7 +270,7 @@ survey
   background: #ffebec;
   height: 370px;
   float: left;
-  width: 126px;
+  width: 116px;
 }
 .bg div:nth-of-type(2) {
   background: #fff3f3;
@@ -287,8 +287,8 @@ survey
 
 .manager {
   position: absolute;
-  right: 50px;
-  top: -50px;
+  right: 100px;
+  top: -70px;
   width: 100px;
 }
 .manager h2 {
@@ -316,21 +316,28 @@ survey
 .info {
   position: absolute;
   right: 0;
-  top: 32px;
-  width: 50px;
+  top: -70px;
+  width: 100px;
+}
+.info h2 {
+  font-size: 14px;
+  margin: 0;
+  text-align: center;
+  line-height: 1.2em;
+  font-weight: normal;
 }
 .info ul {
   margin-top: 0;
   padding: 0;
-  list-style: none;
+  border: 1px solid #ccc;
 }
 .info ul li {
-  width: 50px;
-  height: 123.3px;
+  width: 100px;
+  height: 41.1px;
   line-height: 41.1px;
   box-sizing: border-box;
   text-align: center;
-  font-size: 14px;
+  font-size: 20px;
 }
 
 .info-icon {
@@ -351,8 +358,7 @@ padding: 0.5em;
 line-height: 1.3em;
 color: #000; /*文字色*/
 border: 1px solid #000; /*線の太さ・色*/
-border-radius: 8px; /*角の丸み*/
-height:80px;
+height:100px;
 }
 .triangle {
 color: #ff8c00;

--- a/src/result.js
+++ b/src/result.js
@@ -49,10 +49,8 @@ $(document).ready(() => {
   //スマホ用のテーブルを描画
   for(let i = 0; i < labels.length; i++) {
     let info_icon = "";
-    if(i % 3 == 0) {
-      const modal = (i/3) + 1;
-      info_icon = `<td rowspan="3"><a class="info-icon" href="#" data-toggle="modal" data-target="#my-modal-${modal}"><i class="fas fa-exclamation-circle"></i></a></td>`;
-    }
+    const modal = Math.floor((i/3) + 1);
+    info_icon = `<td><a class="info-icon" href="#" data-toggle="modal" data-target="#my-modal-${modal}"><i class="fas fa-exclamation-circle"></i></a></td>`;
     $(".table > tbody").append(`<tr><th>${labels[i]}</th><td>${userScore[i]}</td><td>${managerMeanScore[i]}</td><td>${memberMeanScore[i]}</td><td>${gap[i]}</td>${info_icon}</tr>`);
   }
 
@@ -100,6 +98,7 @@ $(document).ready(() => {
 
   const options = {
     responsive: true,
+    maintainAspectRatio: false,
     scales: {
       yAxes: [{
         ticks: {
@@ -108,7 +107,6 @@ $(document).ready(() => {
       }]
     }
   };
-
   const ex_chart = new Chart(ctx, {
     type: 'horizontalBar',
     data: data,

--- a/surveyresults.html
+++ b/surveyresults.html
@@ -65,9 +65,16 @@
 				</ul>
 			</div>
 			<div class="info">
+				<h2 class="kakoi">ソリューション例と営業サプリの参考コンテンツはこちら！</h2>
 				<ul>
 					<li><a class="info-icon" href="#" data-toggle="modal" data-target="#my-modal-1"><i class="fas fa-exclamation-circle"></i></a></li>
+					<li><a class="info-icon" href="#" data-toggle="modal" data-target="#my-modal-1"><i class="fas fa-exclamation-circle"></i></a></li>
+					<li><a class="info-icon" href="#" data-toggle="modal" data-target="#my-modal-1"><i class="fas fa-exclamation-circle"></i></a></li>
 					<li><a class="info-icon" href="#" data-toggle="modal" data-target="#my-modal-2"><i class="fas fa-exclamation-circle"></i></a></li>
+					<li><a class="info-icon" href="#" data-toggle="modal" data-target="#my-modal-2"><i class="fas fa-exclamation-circle"></i></a></li>
+					<li><a class="info-icon" href="#" data-toggle="modal" data-target="#my-modal-2"><i class="fas fa-exclamation-circle"></i></a></li>
+					<li><a class="info-icon" href="#" data-toggle="modal" data-target="#my-modal-3"><i class="fas fa-exclamation-circle"></i></a></li>
+					<li><a class="info-icon" href="#" data-toggle="modal" data-target="#my-modal-3"><i class="fas fa-exclamation-circle"></i></a></li>
 					<li><a class="info-icon" href="#" data-toggle="modal" data-target="#my-modal-3"><i class="fas fa-exclamation-circle"></i></a></li>
 				</ul>
 			</div>


### PR DESCRIPTION
fixed #25 

表示内容こんな感じでどうでしょうか？


# 修正内容

- 「ソリューション例と営業サプリの参考コンテンツはこちら！」といれる
  - 幅は「マネージャー平均とのGAP」の列と同じ100pxにしています。
  - 枠に入り切らなかったので、高さを10px追加しました。
-  !マークのアイコンのサイズを大きくして、センタリングする
    - 14px から 20pxにしました。
    - センタリングは元々設定されていました。
    - モーダルの内容は3種類のまま、上から1-3番、4-6番、7-9番はそれぞれ同じ内容が表示されます。

[![Image from Gyazo](https://i.gyazo.com/4a5a1a00e3d749d52ddb985624eddfab.png)](https://gyazo.com/4a5a1a00e3d749d52ddb985624eddfab)

スマホ表示
[![Image from Gyazo](https://i.gyazo.com/9402c9d340d46c52b02238b9e7091692.png)](https://gyazo.com/9402c9d340d46c52b02238b9e7091692)
